### PR TITLE
Next release

### DIFF
--- a/dev/elin/task/doc.clj
+++ b/dev/elin/task/doc.clj
@@ -248,7 +248,7 @@
                                (->> interceptor
                                     (map #(format "* %s" (asciidoc/anchor (interceptor-title %)))))]
                               (format "Calls %s handler." (asciidoc/anchor title)))]
-                   [(format "===== %s" command)
+                   [(format "==== %s" command)
                     ""
                     body
                     ""]))))

--- a/doc/elin-mapping.txt
+++ b/doc/elin-mapping.txt
@@ -383,6 +383,18 @@ MAPPINGS                                                         *elin-mappings*
 <Plug>(elin_clear_virtual_texts)
   Same as |ElinClearVirtualTexts|.
 
+                                                          *<Plug>(elin_op_eval)*
+<Plug>(elin_op_eval)
+  Same as |ElinOperatorEval|.
+
+                                               *<Plug>(elin_op_eval_in_context)*
+<Plug>(elin_op_eval_in_context)
+  Same as |ElinOperatorEvalInContext|.
+
+                                                 *<Plug>(elin_op_macroexpand_1)*
+<Plug>(elin_op_macroexpand_1)
+  Same as |ElinOperatorMacroExpand1|.
+
 ------------------------------------------------------------------------------
 DEFAULT MAPPINGS                                         *elin-default-mappings*
 

--- a/doc/pages/index.adoc
+++ b/doc/pages/index.adoc
@@ -119,12 +119,8 @@ Interceptors intercept various processes and change their behavior.
 === Built-in Interceptors
 include::./generated/interceptors.adoc[]
 
-
-== Host
-=== Vim/Neovim
-==== Commands
-include::./generated/commands.adoc[]
-
+== Vim/Neovim
+include::./vim_neovim/index.adoc[]
 
 // == Tips
 // include::./tips/index.adoc[]

--- a/doc/pages/vim_neovim/index.adoc
+++ b/doc/pages/vim_neovim/index.adoc
@@ -1,0 +1,38 @@
+=== Commands
+include::../generated/commands.adoc[]
+
+=== Operators
+
+Elin provides following operators.
+
+[%autowidth,cols="a,a"]
+|===
+| Operator | Description
+
+| `<Plug>(elin_op_eval)`
+| Evaluate codes.
+This operator uses <<_handler_evaluateevaluate>> handler.
+
+| `<Plug>(elin_op_eval_in_context)`
+| Evaludate codes in context.
+This operator uses <<_handler_evaluateevaluate>> handler with <<_interceptor_evaluateeval_with_context>> interceptor.
+
+| `<Plug>(elin_op_macroexpand_1)`
+| Exapnd macro once.
+This operator uses <<_handler_evaluateexpand_1>> handler.
+
+|===
+
+It is useful to combinate these operators with vim-sexp's motions like follows. (Change the mapping key as you like)
+
+.Example
+[source,vim]
+----
+aug MyElinOperatorSetting
+  au!
+  au FileType clojure nmap <buffer> <Leader>exe
+      \ <Plug>(elin_op_eval)<Plug>(sexp_outer_list)``
+aug END
+----
+
+

--- a/plugin/elin.vim
+++ b/plugin/elin.vim
@@ -208,6 +208,10 @@ nnoremap <silent> <Plug>(elin_clear_info_buffer) <Cmd>ElinClearInfoBuffer<CR>
 nnoremap <silent> <Plug>(elin_clear_virtual_texts) <Cmd>ElinClearVirtualTexts<CR>
 " }}}
 
+" Operators {{{
+nnoremap <silent> <Plug>(elin_op_eval) :<C-u>set opfunc=ElinOperatorEval<CR>g@
+" }}}
+
 " Default key mappings {{{
 if exists('g:elin_enable_default_key_mappings')
       \ && g:elin_enable_default_key_mappings

--- a/plugin/elin.vim
+++ b/plugin/elin.vim
@@ -210,6 +210,7 @@ nnoremap <silent> <Plug>(elin_clear_virtual_texts) <Cmd>ElinClearVirtualTexts<CR
 
 " Operators {{{
 nnoremap <silent> <Plug>(elin_op_eval) :<C-u>set opfunc=ElinOperatorEval<CR>g@
+nnoremap <silent> <Plug>(elin_op_eval_in_context) :<C-u>set opfunc=ElinOperatorEvalInContext<CR>g@
 nnoremap <silent> <Plug>(elin_op_macroexpand_1) :<C-u>set opfunc=ElinOperatorMacroExpand1<CR>g@
 " }}}
 

--- a/plugin/elin.vim
+++ b/plugin/elin.vim
@@ -210,6 +210,7 @@ nnoremap <silent> <Plug>(elin_clear_virtual_texts) <Cmd>ElinClearVirtualTexts<CR
 
 " Operators {{{
 nnoremap <silent> <Plug>(elin_op_eval) :<C-u>set opfunc=ElinOperatorEval<CR>g@
+nnoremap <silent> <Plug>(elin_op_macroexpand_1) :<C-u>set opfunc=ElinOperatorMacroExpand1<CR>g@
 " }}}
 
 " Default key mappings {{{

--- a/plugin/operator.vim
+++ b/plugin/operator.vim
@@ -14,6 +14,12 @@ function! ElinOperatorEval(type) abort
   return elin#notify('elin.handler.evaluate/evaluate', [code, opt])
 endfunction
 
+function! ElinOperatorEvalInContext(type) abort
+  let code = s:get_code()
+  let opt = json_encode({'use-base-params': 1})
+  return elin#notify('elin-alias-evaluate-in-context', [code, opt])
+endfunction
+
 function! ElinOperatorMacroExpand1(type) abort
   let code = s:get_code()
   return elin#notify('elin.handler.evaluate/expand-1', [code])

--- a/plugin/operator.vim
+++ b/plugin/operator.vim
@@ -1,0 +1,15 @@
+function! s:get_code() abort
+  let reg_save = @@
+  try
+    silent exe 'normal! `[v`]y'
+    return @@
+  finally
+    let @@ = reg_save
+  endtry
+endfunction
+
+function! ElinOperatorEval(type) abort
+  let code = s:get_code()
+  let opt = json_encode({'use-base-params': 1})
+  return elin#notify('elin.handler.evaluate/evaluate', [code, opt])
+endfunction

--- a/plugin/operator.vim
+++ b/plugin/operator.vim
@@ -13,3 +13,8 @@ function! ElinOperatorEval(type) abort
   let opt = json_encode({'use-base-params': 1})
   return elin#notify('elin.handler.evaluate/evaluate', [code, opt])
 endfunction
+
+function! ElinOperatorMacroExpand1(type) abort
+  let code = s:get_code()
+  return elin#notify('elin.handler.evaluate/expand-1', [code])
+endfunction

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -79,6 +79,7 @@
                   elin.handler.evaluate/evaluate-current-list {:interceptor #ref [:interceptor :preset :evaluation]}
                   elin.handler.evaluate/evaluate-current-top-list {:interceptor #ref [:interceptor :preset :evaluation]}
                   elin.handler.evaluate/evaluate-namespace-form {:interceptor {:includes [elin.interceptor.evaluate/output-eval-result-to-cmdline]}}
+                  elin.handler.evaluate/expand-1 {:interceptor {:uses [elin.interceptor.handler/append-result-to-info-buffer {:show-temporarily? true}]}}
                   elin.handler.evaluate/expand-1-current-list {:interceptor {:uses [elin.interceptor.handler/append-result-to-info-buffer {:show-temporarily? true}]}}
                   elin.handler.evaluate/interrupt {:interceptor {:includes [elin.interceptor.nrepl/output-result-to-cmdline]}}
                   elin.handler.evaluate/print-last-result {:interceptor {:uses [elin.interceptor.handler/append-result-to-info-buffer {:show-temporarily? true}]}}

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -160,7 +160,10 @@
                                                            :config {:interceptor {:includes [elin.interceptor.handler/overview]
                                                                                   :excludes [elin.interceptor.evaluate/output-eval-result-to-cmdline
                                                                                              elin.interceptor.evaluate/set-eval-result-to-virtual-text
-                                                                                             elin.interceptor.evaluate/yank-eval-result]}}}}
+                                                                                             elin.interceptor.evaluate/yank-eval-result]}}}
+                     ;; Used in operator
+                     elin-alias-evaluate-in-context {:handler elin.handler.evaluate/evaluate
+                                                     :config {:interceptor {:includes [elin.interceptor.evaluate/eval-with-context]}}}}
 
            :initialize {:export {"g:elin_http_server_port" #ref [:http-server :port]}}}
 

--- a/src/elin/function/evaluate.clj
+++ b/src/elin/function/evaluate.clj
@@ -44,8 +44,12 @@
 (defn evaluate-code
   ([elin code]
    (evaluate-code elin code {}))
-  ([{:component/keys [nrepl]} code options]
-   (eval!! nrepl code options)))
+  ([{:as elin :component/keys [nrepl]} code options]
+   (e/let [base-params (when (:use-base-params options)
+                         (get-base-params elin))]
+     (->> (merge options
+                 base-params)
+          (eval!! nrepl code)))))
 
 (defn evaluate-current-top-list
   ([elin]

--- a/src/elin/handler/evaluate.clj
+++ b/src/elin/handler/evaluate.clj
@@ -1,5 +1,6 @@
 (ns elin.handler.evaluate
   (:require
+   [cheshire.core :as json]
    [clojure.core.async :as async]
    [clojure.pprint :as pp]
    [elin.constant.interceptor :as e.c.interceptor]
@@ -30,11 +31,11 @@
 (defn evaluate
   "Evaluate specified code."
   [{:as elin :keys [message]}]
-  (let [code (->> message
-                  (:params)
-                  (first))]
-    (e/->> {:middleware (evaluate-interceptor-middleware elin)}
-           (e.f.evaluate/evaluate-code elin code)
+  (let [[code option-json] (:params message)
+        option (merge (when (string? option-json)
+                        (json/parse-string option-json keyword))
+                      {:middleware (evaluate-interceptor-middleware elin)})]
+    (e/->> (e.f.evaluate/evaluate-code elin code option)
            (:response)
            (:value))))
 

--- a/src/elin/handler/evaluate.clj
+++ b/src/elin/handler/evaluate.clj
@@ -128,6 +128,17 @@
   (e/let [ns-str (e.f.sexpr/get-namespace elin)]
     (e.f.n.cider/undef-all!! nrepl ns-str)))
 
+(defn expand-1
+  "Expand macro code once."
+  [{:as elin :keys [message]}]
+  (e/let [[code] (:params message)
+          ns-str (e/error-or (e.f.sexpr/get-namespace elin))
+          resp (e.f.evaluate/expand-1 elin ns-str code)]
+    (with-out-str
+      (-> (:value resp)
+          (read-string)
+          (pp/pprint)))))
+
 (defn expand-1-current-list
   "Expand macro once."
   [{:as elin :component/keys [host]}]

--- a/test/elin/handler/evaluate_test.clj
+++ b/test/elin/handler/evaluate_test.clj
@@ -1,0 +1,25 @@
+(ns elin.handler.evaluate-test
+  (:require
+   [clojure.test :as t]
+   [elin.error :as e]
+   [elin.function.evaluate :as e.f.evaluate]
+   [elin.function.sexpr :as e.f.sexpr]
+   [elin.handler.evaluate :as sut]
+   [elin.test-helper :as h]))
+
+(t/use-fixtures :once h/malli-instrument-fixture)
+(t/use-fixtures :once h/warn-log-level-fixture)
+
+(t/deftest expand-1-test
+  (let [dummy-ns "foo.core"
+        dummy-code "(dummy)"
+        elin (-> (h/test-elin)
+                 (assoc :message {:params [dummy-code]}))]
+    (with-redefs [e.f.sexpr/get-namespace (constantly dummy-ns)
+                  e.f.evaluate/expand-1 (fn [_ ns-str code]
+                                          (if (and (= dummy-ns ns-str)
+                                                   (= dummy-code code))
+                                            {:value (pr-str '(expanded (code)))}
+                                            (e/fault)))]
+      (t/is (= "(expanded (code))\n"
+               (sut/expand-1 elin))))))


### PR DESCRIPTION
- **refactor: Fix to extract base parameters as a function**
- **fix: Fix elin.handler.evaluate/evaluate to add options to use base params**
- **feat: Add vim operator mapping for evaluating code**
- **feat: Add elin.handler.evaluate/expand-1 handler**
- **feat: Add vim operator mapping for macroexpand-1**
- **feat: Add vim operator mapping for evaluating code in context**
- **docs: Update vim help**
- **docs: Add document for vim operators**
- **chore: Update internal files**
